### PR TITLE
fix: bump requests to 2.33.0 (medium-severity CVE)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ langchain-openai==0.3.23
 langchain-core==1.2.11
 langgraph==1.0.10rc1
 pydantic==2.11.7
-requests==2.32.3
+requests==2.33.0
 typing-extensions==4.12.2
 fastapi>=0.109.1
 uvicorn==0.27.0


### PR DESCRIPTION
## Summary
- Bumps `requests` from 2.32.3 to 2.33.0 in `requirements.txt`
- Fixes: Insecure temp file reuse in `extract_zipped_paths()`

## Test plan
- [ ] Verify service builds correctly
- [ ] Confirm no breaking changes