### PR TITLE
fix: bump langchain-openai + python-dotenv (medium CVEs)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 tavily-python==0.7.13
-python-dotenv==1.1.0
+python-dotenv==1.2.2
 langchain==0.3.25
-langchain-openai==0.3.23
+langchain-openai==1.1.14
 langchain-core==1.2.28
 langgraph==1.0.10rc1
 pydantic==2.11.7


### PR DESCRIPTION
## Summary
Consolidates closed Dependabot PRs #18 and #19:
- langchain-openai 0.3.23 → 1.1.14
- python-dotenv 1.1.0 → 1.2.2