### PR TITLE
fix: bump vulnerable dependencies and restore langchain resolvability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ tavily-python==0.7.13
 python-dotenv==1.2.2
 langchain==1.3.9
 langchain-openai==1.1.14
-langchain-core==1.3.3
-langgraph==1.0.10rc1
+langchain-core==1.4.6
+langgraph==1.2.4
 pydantic==2.11.7
 requests==2.33.0
 typing-extensions==4.12.2
@@ -12,6 +12,6 @@ uvicorn==0.27.0
 setuptools==78.1.1
 python-jose
 starlette>=0.40.0
-langgraph-prebuilt==0.2.2
-langchain-tavily==0.2.6
-langchain-groq==0.3.2
+langgraph-prebuilt==1.1.0
+langchain-tavily==0.2.12
+langchain-groq==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests==2.33.0
 typing-extensions==4.12.2
 fastapi>=0.109.1
 uvicorn==0.27.0
-setuptools==78.1.1
+setuptools==83.0.0
 python-jose
 starlette>=0.40.0
 langgraph-prebuilt==1.1.0


### PR DESCRIPTION
## Summary
Resolves the open Dependabot alert in this repo and restores pip resolvability after the langchain 1.3.9 bump.

Security bump:
- `setuptools` 78.1.1 → 83.0.0 (medium) — path traversal in `PackageIndex` when downloading from a malicious index

Compatibility bumps: langchain 1.3.9 requires langchain-core>=1.4.6, and the cascading version constraints also required bumping langgraph, langgraph-prebuilt, langchain-tavily, and langchain-groq to their minimal compatible floors.

- `langchain-core` 1.3.3 → 1.4.6 (langchain 1.3.9 needs >=1.4.6)
- `langgraph` 1.0.10rc1 → 1.2.4 (langchain 1.3.9 needs >=1.2.4,<1.3.0)
- `langgraph-prebuilt` 0.2.2 → 1.1.0 (langgraph 1.2.4 needs >=1.1.0,<1.2.0)
- `langchain-tavily` 0.2.6 → 0.2.12 (0.2.6 caps langchain <0.4.0)
- `langchain-groq` 0.3.2 → 1.0.0 (0.3.2 incompatible with langchain-core 1.4.6)

Verified with a real `pip install --dry-run -r requirements.txt` (against PyPI, matching the Dockerfile build) which resolves cleanly with all of the above.

Supersedes #26.

## Test plan
- [ ] Verify service starts/builds correctly
- [ ] Confirm no breaking changes